### PR TITLE
Add support for module path

### DIFF
--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -115,7 +115,7 @@ Napi::Value findModule(const Napi::CallbackInfo& args) {
   // Define error message that may be set by the function that gets the modules
   const char* errorMessage = "";
 
-  uintptr_t module = module::findModule(moduleName.c_str(), args[1].As<Napi::Number>().Int32Value(), &errorMessage);
+  module::Module module = module::findModule(moduleName.c_str(), args[1].As<Napi::Number>().Int32Value(), &errorMessage);
 
   // If an error message was returned from the function getting the module, throw the error.
   // Only throw an error if there is no callback (if there's a callback, the error is passed there).
@@ -124,13 +124,14 @@ Napi::Value findModule(const Napi::CallbackInfo& args) {
     return env.Null();
   }
 
-  if (module == 0) {
+  if (module.start == 0) {
     return env.Null();
   }
 
   // Create a v8 Object (JSON) to store the process information
   Napi::Object moduleInfo = Napi::Object::New(env);
-  moduleInfo.Set(Napi::String::New(env, "modBaseAddr"), Napi::Value::From(env, module));
+  moduleInfo.Set(Napi::String::New(env, "modBaseAddr"), Napi::Value::From(env, module.start));
+  moduleInfo.Set(Napi::String::New(env, "szExePath"), Napi::Value::From(env, module.pathname));
 
   // findModule can either take one or two arguments,
   // three arguments for asychronous use (third argument is the callback)

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -5,8 +5,11 @@
 #include "process.h"
 #include "memoryjs.h"
 
-uintptr_t module::findModule(const char* moduleName, pid_t processId, const char** errorMessage) {
-    uintptr_t address = 0;
+//TODO: Might be ll on other systems
+#define KLF "l"
+
+module::Module module::findModule(const char* moduleName, pid_t processId, const char** errorMessage) {
+    module::Module result;
     bool found = false;
 
     char maps_path[4096];
@@ -15,7 +18,7 @@ uintptr_t module::findModule(const char* moduleName, pid_t processId, const char
 
     if (f == NULL) {
         *errorMessage = "cannot open /proc/.../maps";
-        return 0;
+        return result;
     }
 
     size_t len = 0;
@@ -33,8 +36,12 @@ uintptr_t module::findModule(const char* moduleName, pid_t processId, const char
             continue;
         }
 
-        // We only need the first field, which is the starting address
-        address = strtoul(line, NULL, 16);
+       sscanf(line, "%" KLF "x-%" KLF "x %31s %llx %x:%x %llu", &result.start,
+			&result.end, result.permissions, &result.offset, 
+            &result.dev_major, &result.dev_minor, &result.inode);
+        
+        result.pathname = strchr(line,'/');
+
         found = true;
         break;
     }
@@ -44,8 +51,9 @@ uintptr_t module::findModule(const char* moduleName, pid_t processId, const char
     if (!found) {
         *errorMessage = "unable to find module";
         printf("did not find module %s for pid %d\n", moduleName, processId);
-        return 0;
+        return result;
     }
 
-    return address;
-} 
+    return result;
+
+}

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -4,9 +4,7 @@
 #include "module.h"
 #include "process.h"
 #include "memoryjs.h"
-
-//TODO: Might be ll on other systems
-#define KLF "l"
+#include <cinttypes>
 
 module::Module module::findModule(const char* moduleName, pid_t processId, const char** errorMessage) {
     module::Module result;
@@ -36,11 +34,11 @@ module::Module module::findModule(const char* moduleName, pid_t processId, const
             continue;
         }
 
-       sscanf(line, "%" KLF "x-%" KLF "x %31s %llx %x:%x %llu", &result.start,
-			&result.end, result.permissions, &result.offset, 
-            &result.dev_major, &result.dev_minor, &result.inode);
+       sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
+              &result.end, result.permissions, &result.offset, 
+              &result.dev_major, &result.dev_minor, &result.inode);
         
-        result.pathname = strchr(line,'/');
+        result.pathname = strdup(strchr(line,'/'));
 
         found = true;
         break;

--- a/lib/module.h
+++ b/lib/module.h
@@ -18,6 +18,10 @@ namespace module {
         unsigned dev_minor;
         unsigned long long inode;
         char *pathname;
+
+        ~Module() {
+            delete pathname;
+        }
     };
 
     Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);

--- a/lib/module.h
+++ b/lib/module.h
@@ -8,7 +8,20 @@
 #include <cstdint>
 
 namespace module {
-  uintptr_t findModule(const char* moduleName, pid_t processId, const char** errorMessage);
-};
+
+    struct Module {
+        uintptr_t start;
+        uintptr_t end;
+        char permissions[32];
+        unsigned long long offset;
+        unsigned dev_major;
+        unsigned dev_minor;
+        unsigned long long inode;
+        char *pathname;
+    };
+
+    Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);
+}
+
 #endif
 #pragma once

--- a/lib/module.h
+++ b/lib/module.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unistd.h>
 #include <cstdint>
+#include <stdlib.h>
 
 namespace module {
 
@@ -20,7 +21,7 @@ namespace module {
         char *pathname;
 
         ~Module() {
-            delete pathname;
+            free(pathname);
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "memoryjs",
-  "version": "3.3.1",
-  "description": "Node add-on for memory reading and writing!",
+  "name": "memoryjs-linux",
+  "version": "0.0.1",
+  "description": "Node add-on for memory reading and writing on linux!",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This is to support the new modifications for Crewlink 1.2.0
It reads the Module as a struct, and for now just takes the start address and the path from it.