### PR TITLE
Implement 'findPattern'

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
         "lib/memory.cc",
         "lib/process.cc",
         "lib/module.cc",
+        "lib/pattern.cc",
       ],
       'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
     }

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ module.exports = {
   VEC4: 'vec4',
   VECTOR4: 'vector4',
 
+  // signature type constants
+  NORMAL: 0x0,
+  READ: 0x1,
+  SUBTRACT: 0x2,
+
   // function data type constants
   T_VOID: 0x0,
   T_STRING: 0x1,
@@ -63,6 +68,14 @@ module.exports = {
     }
 
     memoryjs.readBuffer(handle, address, size, callback);
+  },
+
+  findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset, callback) {
+    if (arguments.length === 6) {
+      return memoryjs.findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset);
+    }
+
+    memoryjs.findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset, callback);
   },
 
   closeProcess: memoryjs.closeProcess, // nop

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -33,7 +33,6 @@ public:
     return value;
   }
 
-private:
   void readMemoryData(pid_t pid, uintptr_t address, void *buffer, size_t size);
 };
 #endif

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -3,8 +3,10 @@
 #include "process.h"
 #include "memoryjs.h"
 #include "memory.h"
+#include "pattern.h"
 
 process Process;
+pattern Pattern;
 // module Module;
 memory Memory;
 
@@ -143,6 +145,60 @@ Napi::Value findModule(const Napi::CallbackInfo& args) {
   } else {
     // return JSON
     return moduleInfo;
+  }
+}
+
+Napi::Value findPattern(const Napi::CallbackInfo& args) {
+  Napi::Env env = args.Env();
+
+  // Address of findPattern result
+  uintptr_t address = -1;
+
+  // Define error message that may be set by the function that gets the modules
+  const char* errorMessage = "";
+
+  pid_t hProcess = (pid_t)args[0].As<Napi::Number>().Int64Value();
+
+  std::vector<module::Module> moduleEntries = module::getModules(hProcess, &errorMessage);
+
+  // If en error message was returned from the function getting the modules, throw the error.
+  // Only throw an error if there is no callback (if there's a callback, the error is passed there).
+  if (strcmp(errorMessage, "") && args.Length() != 7) {
+    Napi::Error::New(env, errorMessage).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  for (std::vector<module::Module>::size_type i = 0; i != moduleEntries.size(); i++) {
+    std::string moduleName(args[1].As<Napi::String>().Utf8Value());
+
+    char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
+
+    if (NULL == match) {
+      std::string signature(args[2].As<Napi::String>().Utf8Value());
+
+      short sigType = args[3].As<Napi::Number>().Int32Value();
+      uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
+      uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
+
+      address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
+      break;
+    }
+  }
+
+  // If no error was set by getModules and the address is still the value we set it as, it probably means we couldn't find the module
+  if (strcmp(errorMessage, "") && address == (uintptr_t)-1) errorMessage = "unable to find module";
+
+  // If no error was set by getModules and the addressis -2 this means there was no match to the pattern
+  if (strcmp(errorMessage, "") && address == (uintptr_t)-2) errorMessage = "no match found";
+
+  if (args.Length() == 7) {
+    // Callback to let the user handle the information
+    Napi::Function callback = args[6].As<Napi::Function>();
+    callback.Call(env.Global(), { Napi::String::New(env, errorMessage), Napi::Value::From(env, address) });
+    return env.Null();
+  } else {
+    // return JSON
+    return Napi::Value::From(env, address);
   }
 }
 

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -172,7 +172,7 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
     std::string moduleName(args[1].As<Napi::String>().Utf8Value());
 
     char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
-    if (NULL == match) {
+    if (match != NULL) {
       std::string signature(args[2].As<Napi::String>().Utf8Value());
 
       short sigType = args[3].As<Napi::Number>().Int32Value();
@@ -180,7 +180,9 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
       uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
 
       address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
-      break;
+      if (address != (uintptr_t)-2) {
+        break;
+      }
     }
   }
 

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -417,6 +417,7 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "openProcess"), Napi::Function::New(env, openProcess));
   exports.Set(Napi::String::New(env, "closeProcess"), Napi::Function::New(env, closeProcess));
   exports.Set(Napi::String::New(env, "findModule"), Napi::Function::New(env, findModule));
+  exports.Set(Napi::String::New(env, "findPattern"), Napi::Function::New(env, findPattern));
   exports.Set(Napi::String::New(env, "readMemory"), Napi::Function::New(env, readMemory));
   exports.Set(Napi::String::New(env, "readBuffer"), Napi::Function::New(env, readBuffer));
   return exports;

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -168,18 +168,22 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
     return env.Null();
   }
 
+  uintptr_t baseAddress = 0;
   for (std::vector<module::Module>::size_type i = 0; i != moduleEntries.size(); i++) {
     std::string moduleName(args[1].As<Napi::String>().Utf8Value());
 
     char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
     if (match != NULL) {
+      if (baseAddress == 0) {
+        baseAddress = moduleEntries[i].start;
+      }
       std::string signature(args[2].As<Napi::String>().Utf8Value());
 
       short sigType = args[3].As<Napi::Number>().Int32Value();
       uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
       uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
 
-      address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
+      address = Pattern.findPattern(hProcess, moduleEntries[i], baseAddress, signature.c_str(), sigType, patternOffset, addressOffset);
       if (address != (uintptr_t)-2) {
         break;
       }

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -159,7 +159,9 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
 
   pid_t hProcess = (pid_t)args[0].As<Napi::Number>().Int64Value();
 
-  std::vector<module::Module> moduleEntries = module::getModules(hProcess, &errorMessage);
+  // std::vector<module::Module> moduleEntries = module::getModules(hProcess, &errorMessage);
+  std::string moduleName(args[1].As<Napi::String>().Utf8Value());
+  module::Module foundModule = module::findModule(moduleName.c_str(), hProcess, &errorMessage);
 
   // If en error message was returned from the function getting the modules, throw the error.
   // Only throw an error if there is no callback (if there's a callback, the error is passed there).
@@ -168,22 +170,28 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
     return env.Null();
   }
 
-  for (std::vector<module::Module>::size_type i = 0; i != moduleEntries.size(); i++) {
-    std::string moduleName(args[1].As<Napi::String>().Utf8Value());
+  //for (std::vector<module::Module>::size_type i = 0; i != moduleEntries.size(); i++) {
+  //  std::string moduleName(args[1].As<Napi::String>().Utf8Value());
 
-    char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
+  //  char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
 
-    if (NULL == match) {
-      std::string signature(args[2].As<Napi::String>().Utf8Value());
+  //  if (NULL == match) {
+  //    std::string signature(args[2].As<Napi::String>().Utf8Value());
 
-      short sigType = args[3].As<Napi::Number>().Int32Value();
-      uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
-      uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
+  //    short sigType = args[3].As<Napi::Number>().Int32Value();
+  //    uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
+  //    uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
 
-      address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
-      break;
-    }
-  }
+  //    address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
+  //    break;
+  //  }
+  //}
+  
+  std::string signature(args[2].As<Napi::String>().Utf8Value());
+  short sigType = args[3].As<Napi::Number>().Int32Value();
+  uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
+  uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
+  address = Pattern.findPattern(hProcess, foundModule, signature.c_str(), sigType, patternOffset, addressOffset);
 
   // If no error was set by getModules and the address is still the value we set it as, it probably means we couldn't find the module
   if (strcmp(errorMessage, "") && address == (uintptr_t)-1) errorMessage = "unable to find module";

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -159,7 +159,7 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
 
   pid_t hProcess = (pid_t)args[0].As<Napi::Number>().Int64Value();
 
-  std::vector<module::Module *> moduleEntries = module::getModules(hProcess, &errorMessage);
+  std::vector<module::Module> moduleEntries = module::getModules(hProcess, &errorMessage);
 
   // If en error message was returned from the function getting the modules, throw the error.
   // Only throw an error if there is no callback (if there's a callback, the error is passed there).
@@ -168,10 +168,10 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
     return env.Null();
   }
 
-  for (std::vector<module::Module *>::size_type i = 0; i != moduleEntries.size(); i++) {
+  for (std::vector<module::Module>::size_type i = 0; i != moduleEntries.size(); i++) {
     std::string moduleName(args[1].As<Napi::String>().Utf8Value());
 
-    char *match = strstr(moduleEntries[i]->pathname, moduleName.c_str());
+    char *match = strstr(moduleEntries[i].pathname, moduleName.c_str());
     if (NULL == match) {
       std::string signature(args[2].As<Napi::String>().Utf8Value());
 
@@ -179,19 +179,11 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
       uint32_t patternOffset = args[4].As<Napi::Number>().Int32Value();
       uint32_t addressOffset = args[5].As<Napi::Number>().Int32Value();
 
-      address = Pattern.findPattern(hProcess, *moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
+      address = Pattern.findPattern(hProcess, moduleEntries[i], signature.c_str(), sigType, patternOffset, addressOffset);
       break;
     }
   }
 
-  // Free ModulePointers when done searching.
-  for (std::vector<module::Module *>::size_type i = 0; i != moduleEntries.size(); i++) {
-    delete moduleEntries[i];
-  }
-
-  // Free the moduleEntries vector.
-  moduleEntries.clear();
-  
   // If no error was set by getModules and the address is still the value we set it as, it probably means we couldn't find the module
   if (strcmp(errorMessage, "") && address == (uintptr_t)-1) errorMessage = "unable to find module";
 

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -35,9 +35,9 @@ std::vector<module::Module *> module::getModules(pid_t processId, const char**  
 
         // If the line doesn't have a path, simply add a dummy value to pathname.
         if (strstr(line, "/") != NULL) {
-            result->pathname = strdup(strchr(line,'/'));
+            strcpy(result->pathname, strchr(line,'/'));
         } else {
-            result->pathname = strdup("unknown");
+            strcpy(result->pathname, "unknown");
         }
 
         modules.push_back(result);
@@ -80,7 +80,7 @@ module::Module module::findModule(const char* moduleName, pid_t processId, const
               &result.end, result.permissions, &result.offset, 
               &result.dev_major, &result.dev_minor, &result.inode);
         
-        result.pathname = strdup(strchr(line,'/'));
+        strcpy(result.pathname, strchr(line,'/'));
 
         found = true;
         break;

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -37,7 +37,7 @@ std::vector<module::Module> module::getModules(pid_t processId, const char**  er
         Module result;
 
         sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
-              &result.end, result.permissions, &result.offset, 
+              &result.end, result.permissions, &result.offset,
               &result.dev_major, &result.dev_minor, &result.inode);
 
         // If the line doesn't have a path, simply add a dummy value to pathname.
@@ -82,10 +82,10 @@ module::Module module::findModule(const char* moduleName, pid_t processId, const
             continue;
         }
 
-       sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
-              &result.end, result.permissions, &result.offset, 
+        sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
+              &result.end, result.permissions, &result.offset,
               &result.dev_major, &result.dev_minor, &result.inode);
-        
+
         strcpy(result.pathname, strchr(line,'/'));
 
         found = true;

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -27,6 +27,13 @@ std::vector<module::Module> module::getModules(pid_t processId, const char**  er
             continue;
         }
         line[rc-1] = '\0';
+
+        // Skip '[heap]', '[stack]', etc.
+        // Probably don't need these right now.
+        if (strchr(line, '[') != NULL) {
+            continue;
+        }
+
         Module result;
 
         sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
@@ -34,7 +41,7 @@ std::vector<module::Module> module::getModules(pid_t processId, const char**  er
               &result.dev_major, &result.dev_minor, &result.inode);
 
         // If the line doesn't have a path, simply add a dummy value to pathname.
-        if (strstr(line, "/") != NULL) {
+        if (strchr(line, '/') != NULL) {
             strcpy(prev_pathname, strchr(line, '/'));
         }
         strcpy(result.pathname, prev_pathname);

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -29,16 +29,16 @@ std::vector<module::Module *> module::getModules(pid_t processId, const char**  
         line[rc-1] = '\0';
         result = new Module();
 
-        if (strstr(line, "/") == NULL) {
-            delete result;
-            continue;
-        }
-
         sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result->start,
               &result->end, result->permissions, &result->offset, 
               &result->dev_major, &result->dev_minor, &result->inode);
 
-        result->pathname = strdup(strchr(line,'/'));
+        // If the line doesn't have a path, simply add a dummy value to pathname.
+        if (strstr(line, "/") != NULL) {
+            result->pathname = strdup(strchr(line,'/'));
+        } else {
+            result->pathname = strdup("unknown");
+        }
 
         modules.push_back(result);
     }

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -6,6 +6,42 @@
 #include "memoryjs.h"
 #include <cinttypes>
 
+std::vector<module::Module> module::getModules(pid_t processId, const char**  errorMessage) {
+    std::vector<module::Module> modules;
+
+    char maps_path[4096];
+    snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", processId);
+    FILE *f = fopen(maps_path, "r");
+
+    if (f == NULL) {
+        *errorMessage = "cannot open /proc/.../maps";
+        return modules;
+    }
+
+    size_t len = 0;
+    char *line = NULL;
+    ssize_t rc = 0;
+    while ((rc = getline(&line, &len, f)) != -1) {
+        if (rc < 1) {
+            continue;
+        }
+        line[rc-1] = '\0';
+        module::Module result;
+
+        sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %31s %llx %x:%x %llu", &result.start,
+              &result.end, result.permissions, &result.offset, 
+              &result.dev_major, &result.dev_minor, &result.inode);
+
+        result.pathname = strdup(strchr(line,'/'));
+
+        modules.push_back(result);
+    }
+    free(line);
+    fclose(f);
+
+    return modules;
+}
+
 module::Module module::findModule(const char* moduleName, pid_t processId, const char** errorMessage) {
     module::Module result;
     bool found = false;

--- a/lib/module.h
+++ b/lib/module.h
@@ -26,6 +26,7 @@ namespace module {
     };
 
     Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);
+    std::vector<Module> getModules(pid_t processId, const char**  errorMessage);
 }
 
 #endif

--- a/lib/module.h
+++ b/lib/module.h
@@ -26,7 +26,7 @@ namespace module {
     };
 
     Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);
-    std::vector<Module> getModules(pid_t processId, const char**  errorMessage);
+    std::vector<Module *> getModules(pid_t processId, const char**  errorMessage);
 }
 
 #endif

--- a/lib/module.h
+++ b/lib/module.h
@@ -22,7 +22,7 @@ namespace module {
     };
 
     Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);
-    std::vector<Module *> getModules(pid_t processId, const char**  errorMessage);
+    std::vector<Module> getModules(pid_t processId, const char**  errorMessage);
 }
 
 #endif

--- a/lib/module.h
+++ b/lib/module.h
@@ -18,11 +18,7 @@ namespace module {
         unsigned dev_major;
         unsigned dev_minor;
         unsigned long long inode;
-        char *pathname;
-
-        ~Module() {
-            free(pathname);
-        }
+        char pathname[4096];
     };
 
     Module findModule(const char* moduleName, pid_t processId, const char** errorMessage);

--- a/lib/pattern.cc
+++ b/lib/pattern.cc
@@ -1,0 +1,75 @@
+#include <node.h>
+#include <vector>
+#include <cerrno>
+#include <cstring>
+#include <sys/uio.h>
+#include "module.h"
+#include "pattern.h"
+#include "memoryjs.h"
+#include "process.h"
+#include "memory.h"
+
+#define INRANGE(x,a,b) (x >= a && x <= b) 
+#define getBits( x ) (INRANGE(x,'0','9') ? (x - '0') : ((x&(~0x20)) - 'A' + 0xa))
+#define getByte( x ) (getBits(x[0]) << 4 | getBits(x[1]))
+
+pattern::pattern() {}
+pattern::~pattern() {}
+
+/* based off Y3t1y3t's implementation */
+uintptr_t pattern::findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset) { 
+  auto moduleSize = uintptr_t(module.end - module.start);
+  auto moduleBase = uintptr_t(module.start);
+
+  auto moduleBytes = std::vector<unsigned char>(moduleSize);
+
+  struct iovec remote_iov = {.iov_base = (void *)moduleBase, .iov_len = moduleSize};
+  struct iovec local_iov = {.iov_base = &moduleBytes[0], .iov_len = moduleSize};
+
+  ssize_t rc = process_vm_readv(hProcess, &local_iov, 1, &remote_iov, 1, 0);
+
+  if (rc < 0 || (size_t) rc != moduleSize) {
+    printf("error: process_vm_readv returned %zd instead of %zu (%s) address=%#lx\n", rc, moduleSize, strerror(errno), moduleBase);
+  }
+
+  auto byteBase = const_cast<unsigned char*>(&moduleBytes.at(0));
+  auto maxOffset = moduleSize - 0x1000;
+
+  for (auto offset = 0UL; offset < maxOffset; ++offset) {
+    if (compareBytes(byteBase + offset, pattern)) {
+      auto address = moduleBase + offset + patternOffset;
+      struct iovec remote_iov = {.iov_base = (void *)address, .iov_len = sizeof(uintptr_t)};
+      struct iovec local_iov = {.iov_base = &address, .iov_len = sizeof(uintptr_t)};
+
+      /* read memory at pattern if flag is raised*/
+      if (sigType & ST_READ) rc = process_vm_readv(hProcess, &local_iov, 1, &remote_iov, 1, 0);
+
+      if (rc < 0 || (size_t) rc != moduleSize) {
+        printf("error: process_vm_readv returned %zd instead of %zu (%s) address=%#lx\n", rc, moduleSize, strerror(errno), moduleBase);
+      }
+
+      /* subtract image base if flag is raised */
+      if (sigType & ST_SUBTRACT) address -= moduleBase;
+
+      return address + addressOffset;
+    }
+  }
+
+  // the method that calls this will check to see if the value is -2
+	// and throw a 'no match' error
+  return -2;
+};
+
+bool pattern::compareBytes(const unsigned char* bytes, const char* pattern) {
+  for (; *pattern; *pattern != ' ' ? ++bytes : bytes, ++pattern) {
+    if (*pattern == ' ' || *pattern == '?')
+      continue;
+		
+    if (*bytes != getByte(pattern))
+      return false;
+    
+    ++pattern;
+  }
+  
+  return true;
+}

--- a/lib/pattern.cc
+++ b/lib/pattern.cc
@@ -17,7 +17,7 @@ pattern::pattern() {}
 pattern::~pattern() {}
 
 /* based off Y3t1y3t's implementation */
-uintptr_t pattern::findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset) { 
+uintptr_t pattern::findPattern(pid_t hProcess, module::Module module, uintptr_t baseAddress, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset) { 
   memory Memory;
   auto moduleSize = uintptr_t(module.end - module.start);
   auto moduleBase = uintptr_t(module.start);
@@ -37,7 +37,7 @@ uintptr_t pattern::findPattern(pid_t hProcess, module::Module module, const char
       if (sigType & ST_READ) Memory.readMemoryData(hProcess, address, &address, sizeof(uintptr_t));
 
       /* subtract image base if flag is raised */
-      if (sigType & ST_SUBTRACT) address -= moduleBase;
+      if (sigType & ST_SUBTRACT) address -= baseAddress;
 
       return address + addressOffset;
     }

--- a/lib/pattern.cc
+++ b/lib/pattern.cc
@@ -13,13 +13,12 @@
 #define getBits( x ) (INRANGE(x,'0','9') ? (x - '0') : ((x&(~0x20)) - 'A' + 0xa))
 #define getByte( x ) (getBits(x[0]) << 4 | getBits(x[1]))
 
-memory Memory;
-
 pattern::pattern() {}
 pattern::~pattern() {}
 
 /* based off Y3t1y3t's implementation */
 uintptr_t pattern::findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset) { 
+  memory Memory;
   auto moduleSize = uintptr_t(module.end - module.start);
   auto moduleBase = uintptr_t(module.start);
 

--- a/lib/pattern.h
+++ b/lib/pattern.h
@@ -20,7 +20,7 @@ public:
     ST_SUBTRACT = 0x2
   };
 
-  uintptr_t findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset);
+  uintptr_t findPattern(pid_t hProcess, module::Module module, uintptr_t baseAddress, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset);
   bool compareBytes(const unsigned char* bytes, const char* pattern);
 };
 

--- a/lib/pattern.h
+++ b/lib/pattern.h
@@ -1,0 +1,28 @@
+#pragma once
+#ifndef PATTERN_H
+#define PATTERN_H
+
+#include <node.h>
+#include "module.h"
+
+class pattern {
+public:
+  pattern();
+  ~pattern();
+
+  // Signature/pattern types
+  enum {
+    // normal: normal
+    // read: read memory at pattern
+    // subtract: subtract module base
+    ST_NORMAL = 0x0,
+    ST_READ = 0x1,
+    ST_SUBTRACT = 0x2
+  };
+
+  uintptr_t findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset);
+  bool compareBytes(const unsigned char* bytes, const char* pattern);
+};
+
+#endif
+#pragma once

--- a/lib/pattern.h
+++ b/lib/pattern.h
@@ -22,6 +22,9 @@ public:
 
   uintptr_t findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset);
   bool compareBytes(const unsigned char* bytes, const char* pattern);
+
+private:
+  void readMemoryData(pid_t pid, uintptr_t address, void *buffer, size_t size);
 };
 
 #endif

--- a/lib/pattern.h
+++ b/lib/pattern.h
@@ -22,9 +22,6 @@ public:
 
   uintptr_t findPattern(pid_t hProcess, module::Module module, const char* pattern, short sigType, uintptr_t patternOffset, uintptr_t addressOffset);
   bool compareBytes(const unsigned char* bytes, const char* pattern);
-
-private:
-  void readMemoryData(pid_t pid, uintptr_t address, void *buffer, size_t size);
 };
 
 #endif


### PR DESCRIPTION
CrewLink 2.0.0 now requires 'findPattern' in order to function.

Currently I've just added the pattern.cc and pattern.h files, and modified
them a bit.